### PR TITLE
Enable/Disable module option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,43 +44,43 @@ module "elb" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| vpc_id | ID of the VPC to add this ELB to. | string | - | yes |
-| subnet_ids | List of subnet ids to place the ELB into. | list | - | yes |
-| asg_name | Name of the auto scaling group to attach to. If this value is empty, no attachment will be done and is be left to the end-user via custom 'aws_autoscaling_group' or 'aws_autoscaling_attachment' definitions. | string | `` | no |
-| inbound_cidr_blocks | List of CIDR's that are allowed to access the ELB. | list | - | yes |
-| internal | If true, ELB will be an internal ELB. | string | `false` | no |
-| cross_zone_load_balancing | Enable cross-zone load balancing. | string | `true` | no |
-| idle_timeout | The time in seconds that the connection is allowed to be idle. | string | `60` | no |
-| connection_draining | Boolean to enable connection draining. | string | `false` | no |
-| connection_draining_timeout | The time in seconds to allow for connections to drain | string | `300` | no |
-| lb_port | On what port do you want to access the ELB. | string | - | yes |
-| instance_port | On what port does the ELB access the instances. | string | - | yes |
-| lb_protocol | On what protocol should the load balancer respond. | string | `TCP` | no |
-| instance_protocol | On what protocol does the instance respond. | string | `TCP` | no |
-| healthy_threshold | The number of checks before the instance is declared healthy. | string | `10` | no |
-| unhealthy_threshold | The number of checks before the instance is declared unhealthy. | string | `2` | no |
-| target | The target of the check. If unset, will default to 'instance_protocol:instance_port' for TCP/SLL and 'instance_protocol:instance_port/' for HTTP/HTTPS. | string | `` | no |
-| interval | The interval between checks. | string | `30` | no |
-| timeout | The length of time before the check times out. | string | `5` | no |
-| name | Name of the ELB and security group resources. | string | - | yes |
+| enable | Whether or not to enable this module. This is required due to the lack of using count for modules. Set it to false to disable the creation of the ELB. Defaults to true | string | `"true"` | no |
+| vpc\_id | ID of the VPC to add this ELB to. | string | n/a | yes |
+| subnet\_ids | List of subnet ids to place the ELB into. | list | n/a | yes |
+| asg\_name | Name of the auto scaling group to attach to. If this value is empty, no attachment will be done and is be left to the end-user via custom 'aws_autoscaling_group' or 'aws_autoscaling_attachment' definitions. | string | `""` | no |
+| inbound\_cidr\_blocks | List of CIDR's that are allowed to access the ELB. | list | n/a | yes |
+| internal | If true, ELB will be an internal ELB. | string | `"false"` | no |
+| cross\_zone\_load\_balancing | Enable cross-zone load balancing. | string | `"true"` | no |
+| idle\_timeout | The time in seconds that the connection is allowed to be idle. | string | `"60"` | no |
+| connection\_draining | Boolean to enable connection draining. | string | `"false"` | no |
+| connection\_draining\_timeout | The time in seconds to allow for connections to drain | string | `"300"` | no |
+| lb\_port | On what port do you want to access the ELB. | string | n/a | yes |
+| instance\_port | On what port does the ELB access the instances. | string | n/a | yes |
+| lb\_protocol | On what protocol should the load balancer respond. | string | `"TCP"` | no |
+| instance\_protocol | On what protocol does the instance respond. | string | `"TCP"` | no |
+| healthy\_threshold | The number of checks before the instance is declared healthy. | string | `"10"` | no |
+| unhealthy\_threshold | The number of checks before the instance is declared unhealthy. | string | `"2"` | no |
+| target | The target of the check. If unset, will default to 'instance_protocol:instance_port' for TCP/SLL and 'instance_protocol:instance_port/' for HTTP/HTTPS. | string | `""` | no |
+| interval | The interval between checks. | string | `"30"` | no |
+| timeout | The length of time before the check times out. | string | `"5"` | no |
+| name | Name of the ELB and security group resources. | string | n/a | yes |
 | tags | Tags to apply to all resources. | map | `<map>` | no |
-| sg_name_suffix_elb | Name suffix to append to the ELB security group. | string | `-elb` | no |
-| route53_public_dns_name | If set, the ELB will be assigned this public DNS name via Route53. | string | `` | no |
-| route53_private_dns_name | If set, the ELB will be assigned this private DNS name via Route53. | string | `` | no |
-| public_dns_evaluate_target_health | Set to true if you want Route 53 to determine whether to respond to DNS queries using this resource record set by checking the health of the resource record set. | string | `true` | no |
-| private_dns_evaluate_target_health | Set to true if you want Route 53 to determine whether to respond to DNS queries using this resource record set by checking the health of the resource record set. | string | `true` | no |
-
+| sg\_name\_suffix\_elb | Name suffix to append to the ELB security group. | string | `"-elb"` | no |
+| route53\_public\_dns\_name | If set, the ELB will be assigned this public DNS name via Route53. | string | `""` | no |
+| route53\_private\_dns\_name | If set, the ELB will be assigned this private DNS name via Route53. | string | `""` | no |
+| public\_dns\_evaluate\_target\_health | Set to true if you want Route 53 to determine whether to respond to DNS queries using this resource record set by checking the health of the resource record set. | string | `"true"` | no |
+| private\_dns\_evaluate\_target\_health | Set to true if you want Route 53 to determine whether to respond to DNS queries using this resource record set by checking the health of the resource record set. | string | `"true"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| security_group_id | The ID of the ELB security group to attach the the LC/ASG/EC2 instance in order to be accessable by the ELB. |
+| security\_group\_id | The ID of the ELB security group to attach the the LC/ASG/EC2 instance in order to be accessable by the ELB. |
 | id | The name of the ELB |
 | name | The name of the ELB |
 | fqdn | The auto-generated FQDN of the ELB. |
-| route53_public_dns_name | The route53 public dns name of the ELB if set. |
-| route53_private_dns_name | The route53 private dns name of the ELB if set. |
+| route53\_public\_dns\_name | The route53 public dns name of the ELB if set. |
+| route53\_private\_dns\_name | The route53 private dns name of the ELB if set. |
 
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 This Terraform module creates an ELB with optionally a public and/or private Route53 DNS record attached to it.
 Additionally it provides the option to attach the created ELB to an autoscaling group by name.
 
-
 ## Usage
 
 ```hcl
@@ -34,11 +33,9 @@ module "elb" {
 }
 ```
 
-
 ## Examples
 
 * [Complete ELB](examples/complete/)
-
 
 ## Inputs
 
@@ -82,11 +79,9 @@ module "elb" {
 | route53\_public\_dns\_name | The route53 public dns name of the ELB if set. |
 | route53\_private\_dns\_name | The route53 private dns name of the ELB if set. |
 
-
 ## Authors
 
 Module managed by [cytopia](https://github.com/cytopia).
-
 
 ## License
 

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,8 @@
 # ELB
 # -------------------------------------------------------------------------------------------------
 resource "aws_elb" "elb" {
+  count = "${var.enable ? 1 : 0}"
+
   name            = "${var.name}"
   subnets         = ["${var.subnet_ids}"]
   security_groups = ["${aws_security_group.elb.id}"]
@@ -34,6 +36,8 @@ resource "aws_elb" "elb" {
 # Security Groups
 # -------------------------------------------------------------------------------------------------
 resource "aws_security_group" "elb" {
+  count = "${var.enable ? 1 : 0}"
+
   name_prefix = "${var.name}${var.sg_name_suffix_elb}"
   description = "ELB security group for external connection"
   vpc_id      = "${var.vpc_id}"
@@ -69,7 +73,8 @@ resource "aws_security_group" "elb" {
 # ASG Attachment (Optional)
 # -------------------------------------------------------------------------------------------------
 resource "aws_autoscaling_attachment" "asg" {
-  count                  = "${var.asg_name == "" ? 0 : 1}"
+  count = "${var.enable && var.asg_name != "" ? 1 : 0}"
+
   autoscaling_group_name = "${var.asg_name}"
   elb                    = "${aws_elb.elb.id}"
 }
@@ -78,7 +83,8 @@ resource "aws_autoscaling_attachment" "asg" {
 # Route53 DNS (Optional)
 # -------------------------------------------------------------------------------------------------
 resource "aws_route53_record" "public" {
-  count   = "${var.route53_public_dns_name == "" ? 0 : 1}"
+  count = "${var.enable && var.route53_public_dns_name != "" ? 1 : 0}"
+
   zone_id = "${data.aws_route53_zone.public.zone_id}"
   name    = "${var.route53_public_dns_name}"
   type    = "A"
@@ -91,7 +97,8 @@ resource "aws_route53_record" "public" {
 }
 
 resource "aws_route53_record" "private" {
-  count   = "${var.route53_private_dns_name == "" ? 0 : 1}"
+  count = "${var.enable && var.route53_private_dns_name != "" ? 1 : 0}"
+
   zone_id = "${data.aws_route53_zone.private.zone_id}"
   name    = "${var.route53_private_dns_name}"
   type    = "A"
@@ -104,7 +111,8 @@ resource "aws_route53_record" "private" {
 }
 
 data "aws_route53_zone" "public" {
-  count        = "${var.route53_public_dns_name == "" ? 0 : 1}"
+  count = "${var.enable && var.route53_public_dns_name != "" ? 1 : 0}"
+
   private_zone = false
 
   # Removes the first sub-domain part from the FQDN to use as hosted zone.
@@ -112,7 +120,8 @@ data "aws_route53_zone" "public" {
 }
 
 data "aws_route53_zone" "private" {
-  count        = "${var.route53_private_dns_name == "" ? 0 : 1}"
+  count = "${var.enable && var.route53_private_dns_name != "" ? 1 : 0}"
+
   private_zone = true
 
   # Removes the first sub-domain part from the FQDN to use as hosted zone.

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,21 +1,21 @@
 output "security_group_id" {
   description = "The ID of the ELB security group to attach the the LC/ASG/EC2 instance in order to be accessable by the ELB."
-  value       = "${aws_security_group.elb.id}"
+  value       = ["${aws_security_group.elb.*.id}"]
 }
 
 output "id" {
   description = "The name of the ELB"
-  value       = "${aws_elb.elb.id}"
+  value       = ["${aws_elb.elb.*.id}"]
 }
 
 output "name" {
   description = "The name of the ELB"
-  value       = "${aws_elb.elb.name}"
+  value       = ["${aws_elb.elb.*.name}"]
 }
 
 output "fqdn" {
   description = "The auto-generated FQDN of the ELB."
-  value       = "${aws_elb.elb.dns_name}"
+  value       = ["${aws_elb.elb.*.dns_name}"]
 }
 
 output "route53_public_dns_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,12 @@
 # -------------------------------------------------------------------------------------------------
+# Enable/Disable
+# -------------------------------------------------------------------------------------------------
+variable "enable" {
+  description = "Whether or not to enable this module. This is required due to the lack of using count for modules. Set it to false to disable the creation of the ELB. Defaults to true"
+  default     = true
+}
+
+# -------------------------------------------------------------------------------------------------
 # Placement
 # -------------------------------------------------------------------------------------------------
 variable "vpc_id" {


### PR DESCRIPTION
# Enable/Disable module option

Provide option to disable this module as Terraform does not allow count for modules.

## Why

If you want to use this module conditionally within your own module and enable or disable it, there is no way to use `count` on your side, so the module must provide its own mechanism to control disabling/enabling.

## Updates

**Non-breaking change**

This module will be enabled by default (as previous behaviour), but now allows the option via `enable = false` to be disabled.

## Tagging

Due to non-breaking changes, once this PR is merged, master will be tagged by only incrementing the patch level. Resulting tag: `v0.1.5`